### PR TITLE
Bump version for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.1
+
+### Updated
+
+- Updated `crossbeam-channel` to v0.5.6
+- Updated `once_cell` to v0.13.1
+- Updated `serde` to v1.0.444
+
 ## 1.2.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defer-drop"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Nathan West <Lucretiel@gmail.com>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
While I was updating dependencies on one of my projects, I've found out `defer-drop` is not released with the latest dep updates.

I believe this is a PATCH release considering nothing breaking in the unreleased commits.